### PR TITLE
Fix: Resolve 'Unknown font ' error by using .

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,15 +1,15 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import localFont from "next/font/local";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
+const geistSans = localFont({
+  src: '../public/fonts/GeistSans.woff2',
+  variable: '--font-geist-sans',
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+const geistMono = localFont({
+  src: '../public/fonts/GeistMono.woff2',
+  variable: '--font-geist-mono',
 });
 
 export const metadata: Metadata = {


### PR DESCRIPTION
This change updates the font configuration in  to use  for the Geist fonts, which are assumed to be self-hosted. The import statement is updated, and the font files are configured with assumed paths to resolve the 'Unknown font' error.