### PR TITLE
Fix: Resolve React Server Components Error

### DIFF
--- a/components/HoppersHubAI.jsx
+++ b/components/HoppersHubAI.jsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';


### PR DESCRIPTION
This commit adds the "use client" directive to the HoppersHubAI.jsx component. This directive is necessary because the component uses client-side React hooks (useState) and was being treated as a server component by default. Adding this directive ensures the component is rendered on the client-side, resolving the ReactServerComponentsError.